### PR TITLE
プロジェクトの雛形を作成

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,0 +1,18 @@
+name: Format Check
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Set up JDK 1.7
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17.0.10'
+        distribution: 'adopt'
+    - name: Run scalafmtAll format
+      run: sbt scalafmtAll
+    - name: Run scalafix check
+      run: sbt "scalafixAll --check"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+.bsp/

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,9 @@
+version=0.11.1
+rules = [
+  DisableSyntax,
+  OrganizeImports,
+  RemoveUnused,
+]
+project.includeFilters = [
+    "src/main"
+    ]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,6 @@
+version=3.8.0
+runner.dialect = scala213
+project.excludeFilters = [
+    "src/main"
+    ]
+maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,21 @@
+name := "misezan-api"
+
+version := "0.1"
+
+scalaVersion := "2.13.3"
+
+ThisBuild / scalacOptions ++= Seq("-Wunused:imports")
+
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
+  )
+)
+
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor-typed" % "2.6.10",
+  "com.typesafe.akka" %% "akka-http" % "10.2.0",
+  "com.typesafe.akka" %% "akka-stream" % "2.6.10",
+  "com.typesafe.play" %% "play-json" % "2.9.2"
+)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")

--- a/src/main/scala/MyServer.scala
+++ b/src/main/scala/MyServer.scala
@@ -1,0 +1,30 @@
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives._
+
+import scala.concurrent.ExecutionContext
+import scala.io.StdIn
+
+object MySever {
+  def main(args: Array[String]): Unit = {
+    implicit val system = ActorSystem(Behaviors.empty, "mySystem")
+    // 最後のflatMap/onCompleteのために必要になるみたい
+    implicit val executionContext: ExecutionContext = system.executionContext
+
+    val route =
+      path("misezan") {
+        parameters("arg1".as[Int], "arg2".as[Int]) { (arg1, arg2) =>
+          complete((arg1 + arg2).toString + "\n")
+        }
+      }
+
+    val bindingFuture = Http().newServerAt("localhost", 8080).bind(route)
+
+    println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+    StdIn.readLine() // リターンキーを押すまで稼働
+    bindingFuture
+      .flatMap(_.unbind()) // HTTPサーバーを停止
+      .onComplete(_ => system.terminate()) // アクターシステムを終了
+  }
+}


### PR DESCRIPTION
## やったこと
- scalafmtとscalafixを導入し、CIでのチェック環境を構築
- プロジェクトの雛形を作成
  - ビルドツールにsbtを使用
  - Akka HTTPによるRESTful(REST) APIとしている
  - 現在は、与えられた数値の和を返すシステムになっている
  - curlコマンドにより動作確認済み